### PR TITLE
add --no-verify to git commit

### DIFF
--- a/src/update-repo.ts
+++ b/src/update-repo.ts
@@ -111,7 +111,7 @@ function push({
   commitMessage: string
 }) {
   exec(`git add -A`, dir)
-  const result = spawnSync("git", ["commit", "-m", commitMessage], { cwd: dir })
+  const result = spawnSync("git", ["commit", "-m", commitMessage, "--no-verify"], { cwd: dir })
   if (result.status !== 0) {
     throw new Error(`Failed comitting: ${result.output.toString()}`)
   }


### PR DESCRIPTION
Some git hooks are causing [job failures](https://app.circleci.com/pipelines/github/artsy/metaphysics/8819/workflows/165143bd-c676-45f6-9a64-43c848abdb29/jobs/17300). This adds a `--no-verify` flag to git commit invocation.