### PR TITLE
fix: use x-access-token for HTTPS git clone

### DIFF
--- a/src/update-repo.ts
+++ b/src/update-repo.ts
@@ -103,10 +103,9 @@ async function _updateRepo({
 }
 
 function clone({ repo, dir }: CloneArgs) {
-  exec(
-    `git clone https://${process.env.GH_TOKEN}@github.com/${repo.owner}/${repo.repo} ${dir}`,
-    process.cwd(),
-  )
+  const token = process.env.GH_TOKEN!
+  const url = `https://x-access-token:${token}@github.com/${repo.owner}/${repo.repo}`
+  exec(`git clone ${url} ${dir}`, process.cwd())
 }
 
 function push({


### PR DESCRIPTION
GitHub expects personal access tokens in clone URLs as x-access-token:<token>; using only the token as the userinfo segment prompted for a password.

```
Updating schema for artsy-mcp

:: Updating artsy/artsy-mcp ::

• Cloning repo
  git clone https://[redacted]>@github.com/artsy/artsy-mcp /tmp/tmp-1205L3wdgLNbPBxu
Password for 'https://[redacted]@github.com':